### PR TITLE
added a publish_gh_pages

### DIFF
--- a/.github/workflows/publish_gh_pages.yml
+++ b/.github/workflows/publish_gh_pages.yml
@@ -1,0 +1,16 @@
+name: publish_gh_pages
+on:
+  push:
+    branches:
+    - master
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v1
+    - name: Build
+    - run: yarn build
+    - name: Push
+    - run: git push && git subtree push --prefix dist origin gh-pages


### PR DESCRIPTION
I have added a publish_gh_page action.

that runs the steps
`yarn build`
`git push && git subtree push --prefix dist origin gh-pages`

which will run on pushes to master